### PR TITLE
Add candle fetching helper

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,0 +1,48 @@
+import os
+from typing import List
+
+import numpy as np
+import pandas as pd
+from binance.client import Client
+
+
+def fetch_recent_candles(
+    symbol: str = "BTCUSDT",
+    limit: int = 500,
+    interval: str = Client.KLINE_INTERVAL_1MINUTE,
+    return_df: bool = True,
+):
+    """Fetch recent candles for a trading pair from Binance.
+
+    Parameters
+    ----------
+    symbol : str
+        Trading pair symbol, e.g. ``"BTCUSDT"``.
+    limit : int
+        Number of candles to fetch. Binance allows up to 1000.
+    interval : str
+        Kline interval constant from :class:`binance.client.Client`.
+    return_df : bool
+        If ``True``, return a :class:`pandas.DataFrame`; otherwise return a
+        :class:`numpy.ndarray`.
+
+    Returns
+    -------
+    pandas.DataFrame or numpy.ndarray
+        The OHLCV data in the requested format.
+    """
+
+    api_key = os.environ.get("BINANCE_API_KEY")
+    api_secret = os.environ.get("BINANCE_API_SECRET")
+    client = Client(api_key, api_secret)
+
+    klines = client.get_klines(symbol=symbol, interval=interval, limit=limit)
+    data: List[List[float]] = [
+        [float(k[1]), float(k[2]), float(k[3]), float(k[4]), float(k[5])] for k in klines
+    ]
+
+    client.close_connection()
+
+    if return_df:
+        return pd.DataFrame(data, columns=["open", "high", "low", "close", "volume"])
+    return np.array(data, dtype=np.float32)


### PR DESCRIPTION
## Summary
- add `fetch_recent_candles` utility to retrieve OHLCV data from Binance

## Testing
- `python -m py_compile binance_env.py data_fetcher.py`


------
https://chatgpt.com/codex/tasks/task_e_6843668eee0483279dcd6588811d80e1