### PR TITLE
Add CryptoEnv and training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,23 @@ jupyter lab
 ```
 
 Dann öffne `CryptoRL_Starter_with_Agent.ipynb` und folge den Schritten.
+
 ### Nutzung des Environments
 
 ```python
 from binance_env import BinanceTradingEnv
 env = BinanceTradingEnv()
 obs = env.reset()
+```
+
+### Training eines PPO-Agenten
+
+Neben dem Notebook kann ein Agent auch per Skript trainiert werden. Das Skript
+`train_agent.py` verwendet das vereinfachte `CryptoEnv` und speichert nach
+100.000 Schritten das Modell.
+
+```bash
+python train_agent.py
 ```
 
 

--- a/crypto_env.py
+++ b/crypto_env.py
@@ -1,0 +1,101 @@
+import numpy as np
+import gym
+from gym import spaces
+
+
+class CryptoEnv(gym.Env):
+    """Simple cryptocurrency trading environment with synthetic data."""
+
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self, window_size: int = 60, max_steps: int = 1000):
+        super().__init__()
+        self.window_size = window_size
+        self.max_steps = max_steps
+        self.observation_space = spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(self.window_size, 5),
+            dtype=np.float32,
+        )
+        self.action_space = spaces.Discrete(3)
+        self.data = None
+        self.current_step = None
+        self.position = None
+        self.entry_price = None
+        self.unrealized_profit = None
+
+    def _generate_data(self):
+        price = 100.0
+        data = []
+        for _ in range(self.max_steps + self.window_size):
+            change = np.random.randn() * 0.5
+            open_p = price
+            close = price + change
+            high = max(open_p, close) + abs(np.random.randn())
+            low = min(open_p, close) - abs(np.random.randn())
+            volume = np.random.rand() * 100
+            data.append([open_p, high, low, close, volume])
+            price = close
+        return data
+
+    def reset(self):
+        self.data = self._generate_data()
+        self.current_step = self.window_size
+        self.position = 0
+        self.entry_price = 0.0
+        self.unrealized_profit = 0.0
+        return np.array(
+            self.data[self.current_step - self.window_size : self.current_step],
+            dtype=np.float32,
+        )
+
+    def step(self, action: int):
+        assert self.action_space.contains(action)
+
+        if self.current_step >= len(self.data) - 1:
+            obs = np.array(
+                self.data[self.current_step - self.window_size : self.current_step],
+                dtype=np.float32,
+            )
+            return obs, 0.0, True, {}
+
+        candle = self.data[self.current_step]
+        price = candle[3]  # closing price
+        prev_unrealized = self.unrealized_profit
+
+        if action == 1:  # Buy
+            if self.position != 1:
+                self.position = 1
+                self.entry_price = price
+        elif action == 2:  # Sell
+            if self.position != -1:
+                self.position = -1
+                self.entry_price = price
+
+        if self.position == 1:
+            self.unrealized_profit = price - self.entry_price
+        elif self.position == -1:
+            self.unrealized_profit = self.entry_price - price
+        else:
+            self.unrealized_profit = 0.0
+
+        reward = self.unrealized_profit - prev_unrealized
+        self.current_step += 1
+        obs = np.array(
+            self.data[self.current_step - self.window_size : self.current_step],
+            dtype=np.float32,
+        )
+        done = self.current_step >= len(self.data)
+        info = {"position": self.position, "unrealized_profit": self.unrealized_profit}
+        return obs, reward, done, info
+
+    def render(self, mode="human"):
+        if mode == "human":
+            last = self.data[self.current_step - 1]
+            print(
+                f"Close: {last[3]} | Position: {self.position} | Unrealized P/L: {self.unrealized_profit}"
+            )
+
+    def close(self):
+        pass

--- a/train_agent.py
+++ b/train_agent.py
@@ -1,0 +1,13 @@
+from stable_baselines3 import PPO
+from crypto_env import CryptoEnv
+
+
+def main():
+    env = CryptoEnv()
+    model = PPO("MlpPolicy", env, verbose=1)
+    model.learn(total_timesteps=100_000)
+    model.save("ppo_cryptoenv")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a lightweight `CryptoEnv` with synthetic data
- add `train_agent.py` that trains a PPO agent for 100k steps and saves the model
- document how to launch the training in README

## Testing
- `pip install stable-baselines3` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843c3d368c483279d0dd7f9d9b8be3b