### PR TITLE
Implement trade logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Ein experimentelles Projekt zum Trainieren eines Reinforcement-Learning-Agenten 
 - Training & Evaluation direkt im Jupyter Notebook
 - Live-Marktdaten abrufbar
 - Custom Gym-Environment `BinanceTradingEnv` für Echtzeitdaten
+- Logging der Trades in `trading_log.csv`
 
 ## Voraussetzungen
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ def train_and_test(total_timesteps: int = 10000, window_size: int = 60):
     data = fetch_recent_candles(limit=1000, return_df=False)
 
     # Create environment with real data
-    env = DummyVecEnv([lambda: CryptoEnv(window_size=window_size, data=data)])
+    env = DummyVecEnv([lambda: CryptoEnv(window_size=window_size, data=data, log_enabled=True)])
 
     # Train PPO agent
     model = PPO("MlpPolicy", env, verbose=1)
@@ -36,6 +36,7 @@ def train_and_test(total_timesteps: int = 10000, window_size: int = 60):
     plt.tight_layout()
     plt.savefig("equity_curve.png")
     plt.show()
+    env.envs[0].save_trade_log()
 
 
 if __name__ == "__main__":

--- a/train_agent.py
+++ b/train_agent.py
@@ -3,10 +3,11 @@ from crypto_env import CryptoEnv
 
 
 def main():
-    env = CryptoEnv()
+    env = CryptoEnv(log_enabled=True)
     model = PPO("MlpPolicy", env, verbose=1)
     model.learn(total_timesteps=100_000)
     model.save("ppo_cryptoenv")
+    env.save_trade_log()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add trade logging support in `BinanceTradingEnv` and `CryptoEnv`
- log trades to CSV from training scripts
- document trade log in README

## Testing
- `python -m py_compile binance_env.py crypto_env.py train_agent.py main.py`
- `python - <<'PY'
from crypto_env import CryptoEnv
import numpy as np

data = [[1,1,1,1,1]]*200
env = CryptoEnv(window_size=5, data=data, log_enabled=True)
obs = env.reset()
_,_,_,_ = env.step(1)
_,_,_,_ = env.step(2)
print(len(env.trade_log), env.trade_log[0].keys())
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843cd8a53288327875a645f86cdd701