### PR TITLE
Use MEXC keys from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ python train_agent.py
 Vor dem Start sollten die Umgebungsvariablen `BINANCE_API_KEY` und
 `BINANCE_API_SECRET` mit den Zugangsdaten des Testnet-Accounts gesetzt sein.
 
+Für die MEXC-Integration werden die Schlüssel ebenfalls über Umgebungsvariablen
+geladen. Lege dazu eine `.env`-Datei im Projektverzeichnis mit
+`MEXC_API_KEY` und `MEXC_API_SECRET` an. Die Module laden diese Werte beim
+Start automatisch.
+
 
 
 ## Equity-Kurve berechnen

--- a/mexc/__init__.py
+++ b/mexc/__init__.py
@@ -1,0 +1,6 @@
+"""MEXC utilities for reinforcement learning."""
+
+from dotenv import load_dotenv, find_dotenv
+
+# Load .env from project root so API keys are available
+load_dotenv(find_dotenv(), override=False)

--- a/mexc/data_feeder.py
+++ b/mexc/data_feeder.py
@@ -4,21 +4,23 @@ from typing import List
 import numpy as np
 import pandas as pd
 from mexc_sdk import Spot
-import yaml
+from dotenv import load_dotenv, find_dotenv
 
 
 SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "config", "settings.yml")
 
+# Load environment variables from a .env file if present
+load_dotenv(find_dotenv())
+
 
 def _load_api_credentials():
-    """Load API key/secret from env vars or settings file."""
+    """Load API key and secret from environment variables."""
     key = os.environ.get("MEXC_API_KEY") or os.environ.get("MEXC_KEY")
     secret = os.environ.get("MEXC_API_SECRET") or os.environ.get("MEXC_SECRET")
-    if (not key or not secret) and os.path.exists(SETTINGS_PATH):
-        with open(SETTINGS_PATH, "r") as f:
-            settings = yaml.safe_load(f) or {}
-        key = key or settings.get("api_key")
-        secret = secret or settings.get("api_secret")
+    if not key or not secret:
+        raise EnvironmentError(
+            "MEXC_API_KEY and MEXC_API_SECRET must be set as environment variables"
+        )
     return key, secret
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ stable-baselines3[extra]
 python-binance
 mexc-api-sdk
 pyyaml
+python-dotenv


### PR DESCRIPTION
## Summary
- load `.env` in mexc package
- read MEXC API credentials only from environment variables
- document MEXC `.env` usage
- add `python-dotenv` requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843e47aad248327a575b2033f3867ad