### PR TITLE
Use local mexc sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Ein experimentelles Projekt zum Trainieren eines Reinforcement-Learning-Agenten 
 pip install -r requirements.txt
 ```
 
+Zusätzlich wird das MEXC SDK benötigt, das aktuell nicht als
+PyPI-Paket verfügbar ist. Klone das GitHub-Repository und installiere
+das Paket lokal:
+
+```bash
+git clone https://github.com/MEXCofficial/mexc-api-sdk.git
+pip install -e mexc-api-sdk/dist/python
+```
+
+Alternativ kannst du den Pfad `mexc-api-sdk/dist/python` über die
+Umgebungsvariable `PYTHONPATH` einbinden.
+
 ## Start
 
 ```bash

--- a/mexc/data_feeder.py
+++ b/mexc/data_feeder.py
@@ -1,8 +1,18 @@
 import os
+import sys
 from typing import List
 
 import numpy as np
 import pandas as pd
+
+MEXC_SDK_PATH = os.environ.get("MEXC_SDK_PATH")
+if MEXC_SDK_PATH and os.path.exists(MEXC_SDK_PATH):
+    sys.path.insert(0, MEXC_SDK_PATH)
+else:
+    default_sdk = os.path.join(os.path.dirname(os.path.dirname(__file__)), "mexc-api-sdk", "dist", "python")
+    if os.path.exists(default_sdk):
+        sys.path.insert(0, default_sdk)
+
 from mexc_sdk import Spot
 from dotenv import load_dotenv, find_dotenv
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ gym
 torch
 stable-baselines3[extra]
 python-binance
-mexc-api-sdk
 pyyaml
 python-dotenv


### PR DESCRIPTION
## Summary
- document that MEXC SDK must be installed from GitHub
- load the local MEXC SDK automatically if available
- remove `mexc-api-sdk` from requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843e6d94d288327bf46e92d5ac9114a