### PR TITLE
Handle bundled mexc SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,18 @@ Ein experimentelles Projekt zum Trainieren eines Reinforcement-Learning-Agenten 
 pip install -r requirements.txt
 ```
 
-Zusätzlich wird das MEXC SDK benötigt, das aktuell nicht als
-PyPI-Paket verfügbar ist. Klone das GitHub-Repository und installiere
-das Paket lokal:
+Zusätzlich wird das MEXC SDK benötigt. Eine Kopie liegt bereits unter
+`mexc/mexc_sdk/src` bei. Alternativ kannst du das offizielle Repository
+klonen und lokal installieren:
 
 ```bash
 git clone https://github.com/MEXCofficial/mexc-api-sdk.git
 pip install -e mexc-api-sdk/dist/python
 ```
+
+Wenn du die beigelegte Version verwendest, genügt es die Umgebungsvariable
+`MEXC_SDK_PATH` auf `mexc/mexc_sdk/src` zu setzen. Das Skript prüft diesen
+Pfad automatisch.
 
 Alternativ kannst du den Pfad `mexc-api-sdk/dist/python` über die
 Umgebungsvariable `PYTHONPATH` einbinden.

--- a/mexc/data_feeder.py
+++ b/mexc/data_feeder.py
@@ -12,6 +12,10 @@ else:
     default_sdk = os.path.join(os.path.dirname(os.path.dirname(__file__)), "mexc-api-sdk", "dist", "python")
     if os.path.exists(default_sdk):
         sys.path.insert(0, default_sdk)
+    else:
+        local_sdk = os.path.join(os.path.dirname(__file__), "mexc_sdk", "src")
+        if os.path.exists(local_sdk):
+            sys.path.insert(0, local_sdk)
 
 from mexc_sdk import Spot
 from dotenv import load_dotenv, find_dotenv


### PR DESCRIPTION
## Summary
- load local `mexc_sdk` if available
- update README with note on bundled SDK

## Testing
- `python3 -m mexc.train_agent` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6843e98283108327a4b4c3c7b7d583e5