### PR TITLE
Fix MEXC candle fetching

### DIFF
--- a/mexc/data_feeder.py
+++ b/mexc/data_feeder.py
@@ -46,9 +46,9 @@ def fetch_recent_candles(
 ):
     """Fetch recent OHLCV candles from MEXC."""
 
-    api_key, api_secret = _load_api_credentials()
-
-    client = Spot(api_key, api_secret)
+    # ``klines`` is a public endpoint and fails if authentication
+    # headers are sent.  Use an unauthenticated client here.
+    client = Spot()
     options = {"limit": limit} if limit is not None else None
     klines = client.klines(symbol, interval, options)
 


### PR DESCRIPTION
## Summary
- fetch klines without API key

## Testing
- `python - <<'PY'
from mexc.data_feeder import fetch_recent_candles
print('function defined:', callable(fetch_recent_candles))
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6843ed8bbedc8327bde430314c8ba7ff