### PR TITLE
Remove fixed TP/SL logic from training env

### DIFF
--- a/mexc/config/settings.yml
+++ b/mexc/config/settings.yml
@@ -1,7 +1,5 @@
 symbols:
   - ATOMUSDC:
-      take_profit: 0.005  # 0.5% gain
-      stop_loss: 0.002    # 1% loss
       quanty: 25.0 # 0.5 ATOMUSDC
 
 train:

--- a/mexc/live_trader.py
+++ b/mexc/live_trader.py
@@ -62,8 +62,6 @@ def main():
         observations[symbol] = obs
 
     invest_ratio = settings.get("live_trading", {}).get("invest_ratio", 0.1)
-    take_profit = settings.get("live_trading", {}).get("take_profit")
-    stop_loss = settings.get("live_trading", {}).get("stop_loss")
 
     print("Lokale Zeit:", time.time())
     print("🚀 Starte Live-Handel (live) auf MEXC..." )

--- a/mexc/train_agent.py
+++ b/mexc/train_agent.py
@@ -44,7 +44,7 @@ def main():
 
     for symbol_entry in settings.get("symbols", []):
         if isinstance(symbol_entry, dict):
-            # z.B. {'ATOMUSDC': {'take_profit': 0.05, ...}}
+            # z.B. {'ATOMUSDC': {'quantity': 1.0}}
             symbol, config = list(symbol_entry.items())[0]
         else:
             symbol = symbol_entry


### PR DESCRIPTION
## Summary
- drop stop loss/take profit parameters from MexcEnv
- adjust step logic so PPO agent controls trade exits
- clean up training config and example comment
- remove unused variables in live trader

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846806de84c8327865ac79c1d5fa8ef