### PR TITLE
Remove quantity references from MEXC training

### DIFF
--- a/mexc/mexc_env.py
+++ b/mexc/mexc_env.py
@@ -22,7 +22,6 @@ class MexcEnv(gym.Env):
         self.trade_log = []
 
         self.config = config or {}
-        self.quantity = self.config.get("quantity", 0.5)  # aktuell nur informativ
 
         self.observation_space = spaces.Box(
             low=-np.inf,

--- a/mexc/train_agent.py
+++ b/mexc/train_agent.py
@@ -44,7 +44,6 @@ def main():
 
     for symbol_entry in settings.get("symbols", []):
         if isinstance(symbol_entry, dict):
-            # z.B. {'ATOMUSDC': {'quantity': 1.0}}
             symbol, config = list(symbol_entry.items())[0]
         else:
             symbol = symbol_entry


### PR DESCRIPTION
## Summary
- drop unused `quantity` attribute from `MexcEnv`
- clean up comment about quantity in `mexc/train_agent.py`

## Testing
- `python -m py_compile mexc/train_agent.py mexc/mexc_env.py`


------
https://chatgpt.com/codex/tasks/task_e_684682631ce483278def71bf317e2e98