### PR TITLE
Use CPU for PPO training

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ def train_and_test(total_timesteps: int = 10000, window_size: int = 60):
     env = DummyVecEnv([lambda: CryptoEnv(window_size=window_size, data=data, log_enabled=True)])
 
     # Train PPO agent
-    model = PPO("MlpPolicy", env, verbose=1)
+    model = PPO("MlpPolicy", env, verbose=1, device="cpu")
     model.learn(total_timesteps=total_timesteps)
     model.save("ppo_cryptoenv_real")
 

--- a/mexc/config/settings.yml
+++ b/mexc/config/settings.yml
@@ -4,3 +4,4 @@ symbols:
 train:
   window_size: 60
   total_timesteps: 100000
+  device: cpu

--- a/mexc/train_agent.py
+++ b/mexc/train_agent.py
@@ -36,7 +36,7 @@ def main():
 
     window_size = settings.get("train", {}).get("window_size", 60)
     timesteps = settings.get("train", {}).get("total_timesteps", 100_000)
-    device = settings.get("train", {}).get("device", "auto")
+    device = settings.get("train", {}).get("device", "cpu")
 
     agents_dir = os.path.join(base_path, "agents")
     data_dir = os.path.join(base_path, "data")

--- a/train_agent.py
+++ b/train_agent.py
@@ -5,7 +5,7 @@ from trade_analysis import summarize_trades
 
 def main():
     env = CryptoEnv(log_enabled=True)
-    model = PPO("MlpPolicy", env, verbose=1)
+    model = PPO("MlpPolicy", env, verbose=1, device="cpu")
     model.learn(total_timesteps=100_000)
     model.save("ppo_cryptoenv")
     env.save_trade_log()


### PR DESCRIPTION
## Summary
- force CPU device in PPO models
- default to CPU in the MEXC training config

## Testing
- `python -m py_compile train_agent.py main.py mexc/train_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68468d4339f48327b716f961cf6dde4c