### PR TITLE
Fix stochrsi assignment

### DIFF
--- a/mexc/mexc_env.py
+++ b/mexc/mexc_env.py
@@ -46,8 +46,6 @@ class MexcEnv(gym.Env):
 
         df["macd"], df["macd_signal"], df["macd_hist"] = ta.macd(df["close"])
         df["atr"] = ta.atr(df["high"], df["low"], df["close"])
-        df["stochrsi"] = ta.stochrsi(df["close"])
-
         # pandas_ta.stochrsi liefert zwei Spalten (K und D). Wir verwenden die
         # K-Linie und vermeiden damit einen mehrspaltigen DataFrame beim
         # Zuweisen.


### PR DESCRIPTION
## Summary
- prevent multi-column assignment for `stochrsi` in MexcEnv

## Testing
- `python -m py_compile mexc/mexc_env.py`
- `python -m py_compile mexc/train_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6846906839308327b5d468fe1eb3501f