### PR TITLE
Add strategy selection via config and CLI

### DIFF
--- a/mexc/config/settings.yml
+++ b/mexc/config/settings.yml
@@ -1,6 +1,16 @@
 symbols:
   - ICPUSDC
 
+strategies:
+  ma_rsi:
+    indicators: [rsi, ma]
+  macd_atr_stochrsi:
+    indicators: [macd, macd_signal, macd_hist, atr, stochrsi]
+  bollinger_bands:
+    indicators: [bb_lower, bb_middle, bb_upper]
+
+default_strategy: macd_atr_stochrsi
+
 train:
   window_size: 60
   total_timesteps: 100000

--- a/mexc/train_agent.py
+++ b/mexc/train_agent.py
@@ -1,5 +1,6 @@
 import os
 import yaml
+import argparse
 from stable_baselines3 import PPO
 from stable_baselines3.common.callbacks import BaseCallback
 from .mexc_env import MexcEnv
@@ -29,10 +30,19 @@ class EarlyStopCallback(BaseCallback):
 
 
 def main():
+    parser = argparse.ArgumentParser()
     base_path = os.path.dirname(__file__)
     settings_path = os.path.join(base_path, "config", "settings.yml")
     with open(settings_path, "r") as f:
         settings = yaml.safe_load(f)
+
+    parser.add_argument(
+        "--strategy",
+        default=settings.get("default_strategy", "macd_atr_stochrsi"),
+        help="Name der Trading-Strategie",
+    )
+    args = parser.parse_args()
+    strategy = args.strategy
 
     window_size = settings.get("train", {}).get("window_size", 60)
     timesteps = settings.get("train", {}).get("total_timesteps", 100_000)
@@ -56,7 +66,8 @@ def main():
             symbol=symbol,
             window_size=window_size,
             log_enabled=True,
-            config=config  # <== NEU: Konfig an die Umgebung übergeben
+            config=config,
+            strategy=strategy,
         )
 
         model = PPO("MlpPolicy", env, verbose=1, device=device)


### PR DESCRIPTION
## Summary
- define strategies and default in `settings.yml`
- allow passing `--strategy` to training and live trading
- extend `MexcEnv` to support multiple indicator sets
- add Bollinger Bands strategy

## Testing
- `python -m py_compile mexc/mexc_env.py mexc/train_agent.py mexc/live_trader.py`

------
https://chatgpt.com/codex/tasks/task_e_684694ac398c83278ab051464200cacc