### PR TITLE
Update live trading with position check and market orders

### DIFF
--- a/mexc/mexc_api.py
+++ b/mexc/mexc_api.py
@@ -34,6 +34,7 @@ def fetch_symbol_specs(symbol: str):
         if s["symbol"] == symbol:
             qty_precision = 0
             price_precision = 0
+            order_types = s.get("orderTypes", [])
             for f in s["filters"]:
                 if f["filterType"] == "LOT_SIZE":
                     step_size = float(f["stepSize"])
@@ -44,7 +45,8 @@ def fetch_symbol_specs(symbol: str):
 
             symbol_specs[symbol] = {
                 "qty_precision": qty_precision,
-                "price_precision": price_precision
+                "price_precision": price_precision,
+                "order_types": order_types,
             }
             return symbol_specs[symbol]
 


### PR DESCRIPTION
## Summary
- include `order_types` in `fetch_symbol_specs`
- check wallet before buying and skip if asset already present
- use market orders when supported by the symbol

## Testing
- `python -m py_compile mexc/mexc_api.py mexc/live_trader.py`

------
https://chatgpt.com/codex/tasks/task_e_6846e1e6ca6c83279047f3948df422de