### PR TITLE
Modify reward logic and expose via settings

### DIFF
--- a/mexc/config/settings.yml
+++ b/mexc/config/settings.yml
@@ -16,3 +16,9 @@ train:
   window_size: 60
   total_timesteps: 100000
   device: cpu
+
+rewards:
+  hold: 0
+  buy: 1
+  profit_multiplier: 10
+  loss_multiplier: 20

--- a/mexc/finetune_agent.py
+++ b/mexc/finetune_agent.py
@@ -43,6 +43,7 @@ def main():
         window_size=settings.get("train", {}).get("window_size", 60),
         log_enabled=True,
         strategy=args.strategy,
+        config={"rewards": settings.get("rewards", {})},
     )
 
     model = PPO.load(model_path, env=env)

--- a/mexc/live_trader.py
+++ b/mexc/live_trader.py
@@ -71,6 +71,7 @@ def main():
             window_size=window_size,
             log_enabled=False,
             strategy=strategy,
+            config={"rewards": settings.get("rewards", {})},
         )
         obs = env.reset()
         envs[symbol] = env
@@ -149,6 +150,7 @@ def main():
                     data=new_data,
                     log_enabled=False,
                     strategy=strategy,
+                    config={"rewards": settings.get("rewards", {})},
                 )
                 observations[symbol] = envs[symbol].reset()
 

--- a/mexc/train_agent.py
+++ b/mexc/train_agent.py
@@ -72,11 +72,13 @@ def main():
 
         print(f"🚀 Training startet für {symbol}")
 
+        env_config = {**config, "rewards": settings.get("rewards", {})}
+
         env = MexcEnv(
             symbol=symbol,
             window_size=window_size,
             log_enabled=True,
-            config=config,
+            config=env_config,
             strategy=strategy,
         )
 


### PR DESCRIPTION
## Summary
- add global reward configuration in `settings.yml`
- wire reward settings into all Mexc environment usages
- implement new reward calculation in `mexc_env`

## Testing
- `python -m py_compile mexc/mexc_env.py mexc/train_agent.py mexc/finetune_agent.py mexc/live_trader.py`

------
https://chatgpt.com/codex/tasks/task_e_6847387956088327b094eabe4176669b