### PR TITLE
Remove hold reward for Mexc env

### DIFF
--- a/mexc/mexc_env.py
+++ b/mexc/mexc_env.py
@@ -169,12 +169,7 @@ class MexcEnv(gym.Env):
 
         delta_unrealized = self.unrealized_profit - prev_unrealized
         if action == 0:
-            if delta_unrealized > 0:
-                reward = 2 * delta_unrealized
-            elif delta_unrealized < 0:
-                reward = 5 * delta_unrealized
-            else:
-                reward = 0.0
+            reward = 0.0
         else:
             reward = delta_unrealized
 


### PR DESCRIPTION
## Summary
- keep hold actions reward-free in `MexcEnv`

## Testing
- `python -m py_compile mexc/mexc_env.py`


------
https://chatgpt.com/codex/tasks/task_e_684745189e18832793e2d66c9a8b090c